### PR TITLE
Upgrade to Bref 1.0.2 & Extensions (Datadog Tracing)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Location of the layers
-layers := layers/php-base layers/php-lambda layers/php-nginx layers/php-api layers/php-web
+layers := layers/php-base layers/php-extensions layers/php-lambda layers/php-nginx layers/php-api layers/php-web
 
 # The available targets and the default target
 .PHONY: publish build $(layers)
@@ -19,6 +19,9 @@ php-nginx: $(php-lambda)
 
 # php-lambda depends on php-base
 php-lambda: $(php-base)
+
+# php-extensions depends on php-base
+php-extensions: $(php-base)
 
 # The way to make each layer is to sub-make them in their directory
 $(layers):

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ layers := php-base php-extensions php-lambda php-nginx php-api php-web
 .PHONY: publish build $(layers)
 .DEFAULT_GOAL := build
 
-export IMAGE_USER := gbmcarlos
-export IMAGE_TAG := latest
+export IMAGE_USER ?= gbmcarlos
+export IMAGE_TAG ?= 2.0.0
 
 # Delegate 'build' and 'publish' to each layer
 publish build: $(layers)
@@ -25,4 +25,4 @@ php-extensions: $(php-base)
 
 # The way to make each layer is to sub-make them in their directory
 $(layers):
-	$(MAKE) -C "layers/$@" $(TARGET)
+	$(MAKE) IMAGE_TAG=$(IMAGE_TAG) -C "layers/$@" $(TARGET)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Location of the layers
-layers := layers/php-base layers/php-extensions layers/php-lambda layers/php-nginx layers/php-api layers/php-web
+layers := php-base php-extensions php-lambda php-nginx php-api php-web
 
 # The available targets and the default target
 .PHONY: publish build $(layers)
@@ -25,4 +25,4 @@ php-extensions: $(php-base)
 
 # The way to make each layer is to sub-make them in their directory
 $(layers):
-	$(MAKE) -C $@ $(TARGET)
+	$(MAKE) -C "layers/$@" $(TARGET)

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 The purpose of this project is to build a set of PHP environments as Docker images.
 
 ## Stack
-- [**PHP Base**](#php-base): Based on the PHP binaries of [Bref](http://bref.sh/), install composer and a production-ready ini config file
-- [**PHP Extensions**](#php-extensions): Based on *PHP Base*, builds a list of extensions that can be included 
+- [**PHP Base**](#php-base): Based on the PHP binaries of [Bref](http://bref.sh/), install composer, and a production-ready ini config file
+- [**PHP Extensions**](#php-extensions): Based on *PHP Base*, builds a list of extensions that can be easily included 
 - [**PHP Lambda**](#php-lambda): Based on *PHP Base*, add an AWS Lambda [PHP Runtime](https://github.com/gbmcarlos/php-runtime)
 - [**PHP Nginx**](#php-nginx): Based on *PHP Lambda*, install and configure Nginx
 - [**PHP API**](#php-api): Based on *PHP Nginx*, prepare some downstream triggers for a fully functional API project
@@ -11,50 +11,76 @@ The purpose of this project is to build a set of PHP environments as Docker imag
 
 ### PHP Base
 Available as `gbmcarlos/php-base`.
+
 Uses [Bref's](http://bref.sh/) development FPM image, because it contains the appropiate SAPIs, and it contains Xdebug.
-Installs `git` and `zip`, which are required by Composer. 
-Removes Bref's ini file, and copies the production-ready ini file from the official Docker image of PHP
-Installs Composer from their official Docker image.
+
+- Installs `git` and `zip`, which are required by Composer. 
+- Removes Bref's ini file, and copies the production-ready ini file from the official Docker image of PHP
+- Installs Composer from their official Docker image.
 
 ### PHP Extensions
+
 Available as `gbmcarlos/php-ext-{extensions-name}`.
+
 Uses [*PHP Base*](#php-base) as base image.
-For each extension, downloads the source code, builds the extensions, and isolates it in a `scratch` image, to be extracted later from `/opt`
-Includes:
-- [`ddtracer`](https://docs.datadoghq.com/tracing/faq/php-tracer-manual-installation/#install-from-source) (Datadog Tracer)
+
+For each extension:
+- Download the source code 
+- Build the extension
+- Isolate it in a `scratch` image
+
+An extension can be included with
+```dockerfile
+COPY --from=gbmcarlos/php-ext-{extension-name} /opt /opt
+```
+
+Extensions:
+- [`ddtracer` (Datadog Tracer)](https://docs.datadoghq.com/tracing/faq/php-tracer-manual-installation/#install-from-source)
 
 ### PHP Lambda
+
 Available as `gbmcarlos/php-lambda`.
+
 Uses [*PHP Base*](#php-base) as base image.
-Installs a [PHP Runtime](https://github.com/gbmcarlos/php-runtime) from the Docker image.
+
+- Installs a [PHP Runtime](https://github.com/gbmcarlos/php-runtime).
 
 ### PHP Nginx
+
 Available as `gbmcarlos/php-nginx`.
+
 Uses [*PHP Lambda*](#php-lambda) as base image.
-Installs Nginx.
-Configures Nginx permissions.
-Installs an init file to keep Nginx and PHP-FPM running
+
+- Installs Nginx.
+- Configures Nginx permissions.
+- Installs an init file to keep Nginx and PHP-FPM running
 
 ### PHP API
+
 Available as `gbmcarlos/php-api`.
+
 Uses [*PHP Nginx*](#php-nginx) as base image.
-Registers downstream triggers (instructions that will be executed when this image is used a base image, in the child image's context) to:
-- copy the Composer files (`composer.*`)
-- install the Composer dependencies
-- copy the source code (`src` folder)
-- dump the Composer autoloader
-- copy the config files (PHP's ini, PHP-FPM's ini, and Nginx)
+
+- Registers downstream triggers (instructions that will be executed when this image is used a base image, in the child image's context) to:
+    - copy the Composer files (`composer.*`)
+    - install the Composer dependencies
+    - copy the source code (`src` folder)
+    - dump the Composer autoloader
+    - copy the config files (PHP's ini, PHP-FPM's ini, and Nginx)
 
 ### PHP Web
+
 Available as `gbmcarlos/php-api`.
+
 Uses [*PHP Nginx*](#php-nginx) as base image.
-Installs NodeJS
-Registers downstream triggers (instructions that will be executed when this image is used a base image, in the child image's context) to:
-- copy the NPM files (`package*`)
-- install the NPM dependencies
-- copy the Composer files (`composer.*`)
-- install the Composer dependencies
-- copy the source code (`src` folder)
-- compile the Webpack assets
-- dump the Composer autoloader
-- copy the config files (PHP's ini, PHP-FPM's ini, and Nginx)
+
+- Installs NodeJS
+- Registers downstream triggers (instructions that will be executed when this image is used a base image, in the child image's context) to:
+    - copy the NPM files (`package*`)
+    - install the NPM dependencies
+    - copy the Composer files (`composer.*`)
+    - install the Composer dependencies
+    - copy the source code (`src` folder)
+    - compile the Webpack assets
+    - dump the Composer autoloader
+    - copy the config files (PHP's ini, PHP-FPM's ini, and Nginx)

--- a/README.md
+++ b/README.md
@@ -3,28 +3,40 @@ The purpose of this project is to build a set of PHP environments as Docker imag
 
 ## Stack
 - [**PHP Base**](#php-base): Based on the PHP binaries of [Bref](http://bref.sh/), install composer and a production-ready ini config file
+- [**PHP Extensions**](#php-extensions): Based on *PHP Base*, builds a list of extensions that can be included 
 - [**PHP Lambda**](#php-lambda): Based on *PHP Base*, add an AWS Lambda [PHP Runtime](https://github.com/gbmcarlos/php-runtime)
 - [**PHP Nginx**](#php-nginx): Based on *PHP Lambda*, install and configure Nginx
 - [**PHP API**](#php-api): Based on *PHP Nginx*, prepare some downstream triggers for a fully functional API project
 - [**PHP Web**](#php-web): Based on *PHP Nginx*, prepare some downstream triggers for a fully functional Web project
 
 ### PHP Base
+Available as `gbmcarlos/php-base`.
 Uses [Bref's](http://bref.sh/) development FPM image, because it contains the appropiate SAPIs, and it contains Xdebug.
 Installs `git` and `zip`, which are required by Composer. 
 Removes Bref's ini file, and copies the production-ready ini file from the official Docker image of PHP
 Installs Composer from their official Docker image.
 
+### PHP Extensions
+Available as `gbmcarlos/php-ext-{extensions-name}`.
+Uses [*PHP Base*](#php-base) as base image.
+For each extension, downloads the source code, builds the extensions, and isolates it in a `scratch` image, to be extracted later from `/opt`
+Includes:
+- [`ddtracer`](https://docs.datadoghq.com/tracing/faq/php-tracer-manual-installation/#install-from-source) (Datadog Tracer)
+
 ### PHP Lambda
+Available as `gbmcarlos/php-lambda`.
 Uses [*PHP Base*](#php-base) as base image.
 Installs a [PHP Runtime](https://github.com/gbmcarlos/php-runtime) from the Docker image.
 
 ### PHP Nginx
+Available as `gbmcarlos/php-nginx`.
 Uses [*PHP Lambda*](#php-lambda) as base image.
 Installs Nginx.
 Configures Nginx permissions.
 Installs an init file to keep Nginx and PHP-FPM running
 
 ### PHP API
+Available as `gbmcarlos/php-api`.
 Uses [*PHP Nginx*](#php-nginx) as base image.
 Registers downstream triggers (instructions that will be executed when this image is used a base image, in the child image's context) to:
 - copy the Composer files (`composer.*`)
@@ -34,6 +46,7 @@ Registers downstream triggers (instructions that will be executed when this imag
 - copy the config files (PHP's ini, PHP-FPM's ini, and Nginx)
 
 ### PHP Web
+Available as `gbmcarlos/php-api`.
 Uses [*PHP Nginx*](#php-nginx) as base image.
 Installs NodeJS
 Registers downstream triggers (instructions that will be executed when this image is used a base image, in the child image's context) to:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,7 +2,7 @@ version: 0.2
 
 env:
     variables:
-        IMAGE_TAG: 1.0.0
+        IMAGE_TAG: 2.0.0
 
 phases:
     pre_build:

--- a/layers/php-api/Dockerfile
+++ b/layers/php-api/Dockerfile
@@ -4,7 +4,7 @@
 # All these instrucionts will be executed on the downstream Dockerfile (the Dockerfile that uses this image as FROM)
 #####
 
-FROM gbmcarlos/php-nginx as base
+FROM gbmcarlos/php-nginx:2.0.0 as base
 
 ## Composer dependencies
 ### Install just the dependencies, without the code, so no need to dump the autoloader yet

--- a/layers/php-api/Makefile
+++ b/layers/php-api/Makefile
@@ -9,11 +9,9 @@ export IMAGE_REPO := php-api
 
 build:
 	docker build \
-	-t ${IMAGE_USER}/${IMAGE_REPO} \
+	-t ${IMAGE_USER}/${IMAGE_REPO}:${IMAGE_TAG} \
 	--target base \
 	${CURDIR}
 
 publish: build
-	docker tag ${IMAGE_USER}/${IMAGE_REPO} ${IMAGE_USER}/${IMAGE_REPO}:latest
-	docker tag ${IMAGE_USER}/${IMAGE_REPO} ${IMAGE_USER}/${IMAGE_REPO}:${IMAGE_TAG}
-	docker push ${IMAGE_USER}/${IMAGE_REPO}
+	docker push ${IMAGE_USER}/${IMAGE_REPO}:${IMAGE_TAG}

--- a/layers/php-base/Dockerfile
+++ b/layers/php-base/Dockerfile
@@ -12,19 +12,15 @@ FROM composer:2.0 as target-composer
 ### We extract php's production-ready config file from this image
 FROM php:7.4 as target-php
 
-FROM bref/php-74-fpm-dev:0.5.31 as base
+FROM bref/php-74-fpm-dev:1.0.2 as base
 
 ### We need to switch to root to use yum
 USER root
 
-### For some reason, shadow-utils's commands (groupadd and the likes), aren't there, so we need to remove and install it again
 ### According to https://forums.aws.amazon.com/thread.jspa?messageID=755409&tstart=0, we need to install yum-plugin-ovl to avoid errors like "Rpmdb checksum is invalid"
 ### vim, htop, less and tree are utilities to work inside the container more comfortably
 ### git, zip and unzip are necessary for Composer to install dependencies
-RUN     yum remove -y \
-            shadow-utils \
-    &&  yum install -y \
-            shadow-utils \
+RUN     yum install -y \
             yum-plugin-ovl \
             vim htop less tree \
             git zip unzip

--- a/layers/php-base/Dockerfile
+++ b/layers/php-base/Dockerfile
@@ -12,7 +12,7 @@ FROM composer:2.0 as target-composer
 ### We extract php's production-ready config file from this image
 FROM php:7.4 as target-php
 
-FROM bref/php-74-fpm-dev:1.0.2 as base
+FROM bref/php-74-fpm-dev:1.1.1 as base
 
 ### We need to switch to root to use yum
 USER root
@@ -21,6 +21,7 @@ USER root
 ### vim, htop, less and tree are utilities to work inside the container more comfortably
 ### git, zip and unzip are necessary for Composer to install dependencies
 RUN     yum install -y \
+            amazon-linux-extras \
             yum-plugin-ovl \
             vim htop less tree \
             git zip unzip

--- a/layers/php-base/Makefile
+++ b/layers/php-base/Makefile
@@ -9,11 +9,9 @@ export IMAGE_REPO := php-base
 
 build:
 	docker build \
-	-t ${IMAGE_USER}/${IMAGE_REPO} \
+	-t ${IMAGE_USER}/${IMAGE_REPO}:${IMAGE_TAG} \
 	--target base \
 	${CURDIR}
 
 publish: build
-	docker tag ${IMAGE_USER}/${IMAGE_REPO} ${IMAGE_USER}/${IMAGE_REPO}:latest
-	docker tag ${IMAGE_USER}/${IMAGE_REPO} ${IMAGE_USER}/${IMAGE_REPO}:${IMAGE_TAG}
-	docker push ${IMAGE_USER}/${IMAGE_REPO}
+	docker push ${IMAGE_USER}/${IMAGE_REPO}:${IMAGE_TAG}

--- a/layers/php-extensions/Makefile
+++ b/layers/php-extensions/Makefile
@@ -1,0 +1,10 @@
+extensions := ddtrace
+
+.DEFAULT_GOAL := build
+.PHONY: build publish $(extensions)
+
+publish build: $(extensions)
+
+$(extensions):
+	$(MAKE) -C $@ $(TARGET)
+

--- a/layers/php-extensions/ddtrace/Dockerfile
+++ b/layers/php-extensions/ddtrace/Dockerfile
@@ -5,7 +5,7 @@
 
 ARG DD_VERSION=0.53.0
 
-FROM bref/build-php-74:1.0.2 as build
+FROM bref/build-php-74:1.1.1 as build
 
 ARG DD_VERSION
 

--- a/layers/php-extensions/ddtrace/Dockerfile
+++ b/layers/php-extensions/ddtrace/Dockerfile
@@ -1,0 +1,26 @@
+#####
+# This image builds upon php-base
+# Download the source code of ddtrace, `make` it, and isolate in a clean image
+#####
+
+ARG DD_VERSION=0.53.0
+
+FROM bref/build-php-74:1.0.2 as build
+
+ARG DD_VERSION
+
+RUN LD_LIBRARY_PATH= yum install -y \
+        curl-devel
+
+RUN     curl -sL https://github.com/DataDog/dd-trace-php/archive/${DD_VERSION}.tar.gz | tar -xz && cd dd-trace-php-${DD_VERSION} \
+    &&  phpize \
+    &&  ./configure \
+            --enable-option-checking=fatal \
+            --enable-ddtrace \
+    &&  make \
+    &&  make install
+
+FROM scratch as base
+
+# Copy things we installed to the final image
+COPY --from=build /opt/bref/lib/php/extensions/no-debug-non-zts-20190902/ddtrace.so /opt/bref/lib/php/extensions/no-debug-non-zts-20190902/ddtrace.so

--- a/layers/php-extensions/ddtrace/Makefile
+++ b/layers/php-extensions/ddtrace/Makefile
@@ -9,11 +9,9 @@ export IMAGE_REPO := php-ext-ddtrace
 
 build:
 	docker build \
-	-t ${IMAGE_USER}/${IMAGE_REPO} \
+	-t ${IMAGE_USER}/${IMAGE_REPO}:${IMAGE_TAG} \
 	--target base \
 	${CURDIR}
 
 publish: build
-	docker tag ${IMAGE_USER}/${IMAGE_REPO} ${IMAGE_USER}/${IMAGE_REPO}:latest
-	docker tag ${IMAGE_USER}/${IMAGE_REPO} ${IMAGE_USER}/${IMAGE_REPO}:${IMAGE_TAG}
-	docker push ${IMAGE_USER}/${IMAGE_REPO}
+	docker push ${IMAGE_USER}/${IMAGE_REPO}:${IMAGE_TAG}

--- a/layers/php-extensions/ddtrace/Makefile
+++ b/layers/php-extensions/ddtrace/Makefile
@@ -1,0 +1,19 @@
+.DEFAULT_GOAL := build
+.PHONY: publish build
+
+export DOCKER_BUILDKIT ?= 1
+export IMAGE_USER := gbmcarlos
+export IMAGE_TAG := latest
+
+export IMAGE_REPO := php-ext-ddtrace
+
+build:
+	docker build \
+	-t ${IMAGE_USER}/${IMAGE_REPO} \
+	--target base \
+	${CURDIR}
+
+publish: build
+	docker tag ${IMAGE_USER}/${IMAGE_REPO} ${IMAGE_USER}/${IMAGE_REPO}:latest
+	docker tag ${IMAGE_USER}/${IMAGE_REPO} ${IMAGE_USER}/${IMAGE_REPO}:${IMAGE_TAG}
+	docker push ${IMAGE_USER}/${IMAGE_REPO}

--- a/layers/php-lambda/Dockerfile
+++ b/layers/php-lambda/Dockerfile
@@ -3,6 +3,6 @@
 # Here we are going to add gbmcarlos/php-runtime's PHP Runtime Interface Client
 #####
 
-FROM gbmcarlos/php-base as base
+FROM gbmcarlos/php-base:2.0.0 as base
 
-COPY --from=gbmcarlos/php-runtime:1.0.0 /opt /opt
+COPY --from=gbmcarlos/php-runtime:2.0.0 /opt /opt

--- a/layers/php-lambda/Dockerfile
+++ b/layers/php-lambda/Dockerfile
@@ -1,10 +1,8 @@
 #####
 # This image builds upon php-base
-# Here we are going to add gbmcarlos/php-runtime's PHP Lambda Runtime
+# Here we are going to add gbmcarlos/php-runtime's PHP Runtime Interface Client
 #####
-
-FROM gbmcarlos/php-runtime as runtime
 
 FROM gbmcarlos/php-base as base
 
-COPY --from=runtime /opt/bootstrap /opt/bootstrap
+COPY --from=gbmcarlos/php-runtime /opt /opt

--- a/layers/php-lambda/Makefile
+++ b/layers/php-lambda/Makefile
@@ -9,11 +9,9 @@ export IMAGE_REPO := php-lambda
 
 build:
 	docker build \
-	-t ${IMAGE_USER}/${IMAGE_REPO} \
+	-t ${IMAGE_USER}/${IMAGE_REPO}:${IMAGE_TAG} \
 	--target base \
 	${CURDIR}
 
 publish: build
-	docker tag ${IMAGE_USER}/${IMAGE_REPO} ${IMAGE_USER}/${IMAGE_REPO}:latest
-	docker tag ${IMAGE_USER}/${IMAGE_REPO} ${IMAGE_USER}/${IMAGE_REPO}:${IMAGE_TAG}
-	docker push ${IMAGE_USER}/${IMAGE_REPO}
+	docker push ${IMAGE_USER}/${IMAGE_REPO}:${IMAGE_TAG}

--- a/layers/php-nginx/Dockerfile
+++ b/layers/php-nginx/Dockerfile
@@ -7,10 +7,7 @@
 FROM gbmcarlos/php-lambda as base
 
 ## System dependencies
-RUN     yum clean all \
-    &&  yum update -y \
-    &&  yum install -y \
-            nginx
+RUN amazon-linux-extras install nginx1.12
 
 ### Set up permissions
 RUN     groupadd www \

--- a/layers/php-nginx/Dockerfile
+++ b/layers/php-nginx/Dockerfile
@@ -4,7 +4,7 @@
 # The result is an image upon which we can run PHP web applications
 #####
 
-FROM gbmcarlos/php-lambda as base
+FROM gbmcarlos/php-lambda:2.0.0 as base
 
 ## System dependencies
 RUN amazon-linux-extras install \

--- a/layers/php-nginx/Dockerfile
+++ b/layers/php-nginx/Dockerfile
@@ -7,7 +7,8 @@
 FROM gbmcarlos/php-lambda as base
 
 ## System dependencies
-RUN amazon-linux-extras install nginx1.12
+RUN amazon-linux-extras install \
+        nginx1.12
 
 ### Set up permissions
 RUN     groupadd www \

--- a/layers/php-nginx/Makefile
+++ b/layers/php-nginx/Makefile
@@ -9,11 +9,9 @@ export IMAGE_REPO := php-nginx
 
 build:
 	docker build \
-	-t ${IMAGE_USER}/${IMAGE_REPO} \
+	-t ${IMAGE_USER}/${IMAGE_REPO}:${IMAGE_TAG} \
 	--target base \
 	${CURDIR}
 
 publish: build
-	docker tag ${IMAGE_USER}/${IMAGE_REPO} ${IMAGE_USER}/${IMAGE_REPO}:latest
-	docker tag ${IMAGE_USER}/${IMAGE_REPO} ${IMAGE_USER}/${IMAGE_REPO}:${IMAGE_TAG}
-	docker push ${IMAGE_USER}/${IMAGE_REPO}
+	docker push ${IMAGE_USER}/${IMAGE_REPO}:${IMAGE_TAG}

--- a/layers/php-web/Dockerfile
+++ b/layers/php-web/Dockerfile
@@ -4,7 +4,7 @@
 # All these instrucionts will be executed on the downstream Dockerfile (the Dockerfile that uses this image as FROM)
 #####
 
-FROM gbmcarlos/php-nginx as base
+FROM gbmcarlos/php-nginx:2.0.0 as base
 
 ARG NODEJS_VERSION=10
 

--- a/layers/php-web/Makefile
+++ b/layers/php-web/Makefile
@@ -9,11 +9,9 @@ export IMAGE_REPO := php-web
 
 build:
 	docker build \
-	-t ${IMAGE_USER}/${IMAGE_REPO} \
+	-t ${IMAGE_USER}/${IMAGE_REPO}:${IMAGE_TAG} \
 	--target base \
 	${CURDIR}
 
 publish: build
-	docker tag ${IMAGE_USER}/${IMAGE_REPO} ${IMAGE_USER}/${IMAGE_REPO}:latest
-	docker tag ${IMAGE_USER}/${IMAGE_REPO} ${IMAGE_USER}/${IMAGE_REPO}:${IMAGE_TAG}
-	docker push ${IMAGE_USER}/${IMAGE_REPO}
+	docker push ${IMAGE_USER}/${IMAGE_REPO}:${IMAGE_TAG}


### PR DESCRIPTION
upgrade to bref 1.0.2
no need to re-install shadow-utils
install nginx from amazon-linux-extras